### PR TITLE
Align C++ and Python classification accuracy

### DIFF
--- a/model_api/python/openvino/model_api/adapters/openvino_adapter.py
+++ b/model_api/python/openvino/model_api/adapters/openvino_adapter.py
@@ -406,7 +406,6 @@ class OpenvinoAdapter(InferenceAdapter):
             ppp.input(input_idx).preprocess().scale(scale)
 
         self.model = ppp.build()
-        # ov.serialize(self.model, "tmp.xml")
         self.load_model()
 
 

--- a/model_api/python/openvino/model_api/models/classification.py
+++ b/model_api/python/openvino/model_api/models/classification.py
@@ -71,7 +71,6 @@ class ClassificationModel(ImageModel):
     @classmethod
     def parameters(cls):
         parameters = super().parameters()
-        parameters["resize_type"].update_default_value("crop")
         parameters.update(
             {
                 "topk": NumericalValue(value_type=int, default_value=1, min=1),
@@ -85,13 +84,13 @@ class ClassificationModel(ImageModel):
 
     def postprocess(self, outputs, meta):
         outputs = outputs[self.out_layer_name].squeeze()
+        if not np.isclose(np.sum(outputs), 1.0, atol=0.01):
+            outputs = softmax(outputs)
         indices = np.argpartition(outputs, -self.topk)[-self.topk :]
         scores = outputs[indices]
 
         desc_order = scores.argsort()[::-1]
         scores = scores[desc_order]
         indices = indices[desc_order]
-        if not np.isclose(np.sum(outputs), 1.0, atol=0.01):
-            scores = softmax(scores)
         labels = [self.labels[i] if self.labels else "" for i in indices]
         return list(zip(indices, labels, scores))

--- a/model_api/python/openvino/model_api/models/utils.py
+++ b/model_api/python/openvino/model_api/models/utils.py
@@ -122,15 +122,13 @@ def load_labels(label_file):
 
 
 def resize_image(image, size, keep_aspect_ratio=False, interpolation=cv2.INTER_LINEAR):
-    if not keep_aspect_ratio:
-        resized_frame = cv2.resize(image, size, interpolation=interpolation)
-    else:
+    if keep_aspect_ratio:
         h, w = image.shape[:2]
         scale = min(size[1] / h, size[0] / w)
-        resized_frame = cv2.resize(
+        return cv2.resize(
             image, None, fx=scale, fy=scale, interpolation=interpolation
         )
-    return resized_frame
+    return cv2.resize(image, size, interpolation=interpolation)
 
 
 def resize_image_with_aspect(image, size, interpolation=cv2.INTER_LINEAR):

--- a/tests/cpp/accuracy/test_accuracy.cpp
+++ b/tests/cpp/accuracy/test_accuracy.cpp
@@ -92,14 +92,12 @@ TEST_P(ModelParameterizedTest, AccuracyTest)
 
             auto result = model->infer(image);
             auto objects = result->objects;
-            ASSERT_TRUE(objects.size() == modelData.testData[i].reference.size());
+            ASSERT_EQ(objects.size(), modelData.testData[i].reference.size());
 
             for (size_t j = 0; j < objects.size(); j++) {
-                std::stringstream buffer;
-                buffer << objects[j];
-                std::cout << "Buffer: " << buffer.str() << std::endl;
-                std::cout << "Reference: " << modelData.testData[i].reference[j] << std::endl;
-                ASSERT_TRUE(buffer.str() == modelData.testData[i].reference[j]);
+                std::stringstream prediction_buffer;
+                prediction_buffer << objects[j];
+                ASSERT_EQ(prediction_buffer.str(), modelData.testData[i].reference[j]);
             }
         }
     }
@@ -119,11 +117,9 @@ TEST_P(ModelParameterizedTest, AccuracyTest)
 
             ASSERT_GT(topLabels.size(), 0);
             
-            std::stringstream buffer;
-            buffer << topLabels[0];
-            std::cout << "Buffer: " << buffer.str() << std::endl;
-            std::cout << "Reference: " << modelData.testData[i].reference[0] << std::endl;
-            ASSERT_TRUE(buffer.str() == modelData.testData[i].reference[0]); // Check top-1 only
+            std::stringstream prediction_buffer;
+            prediction_buffer << topLabels[0];
+            ASSERT_EQ(prediction_buffer.str(), modelData.testData[i].reference[0]); // Check top-1 only
         }
     }
     else {

--- a/tests/python/accuracy/public_scope.json
+++ b/tests/python/accuracy/public_scope.json
@@ -61,7 +61,7 @@
             {
                 "image": "000000000074.jpg",
                 "reference": [
-                    "(257, Great_Pyrenees, 1.000)"
+                    "(222, kuvasz, 0.145)"
                 ]
             }
         ]
@@ -73,7 +73,7 @@
             {
                 "image": "000000000074.jpg",
                 "reference": [
-                    "(175, Labrador_retriever, 0.928)"
+                    "(175, Labrador_retriever, 0.613)"
                 ]
             }
         ]
@@ -85,7 +85,7 @@
             {
                 "image": "000000000074.jpg",
                 "reference": [
-                    "(245, French_bulldog, 1.000)"
+                    "(245, French_bulldog, 0.152)"
                 ]
             }
         ]

--- a/tests/python/accuracy/test_accuracy.py
+++ b/tests/python/accuracy/test_accuracy.py
@@ -1,16 +1,9 @@
 import json
-import math
-import os
-import sys
-import tempfile
-import time
-from copy import deepcopy
 from pathlib import Path
 
 import cv2
 import numpy as np
 import pytest
-import requests
 from openvino.model_api.models import (
     ClassificationModel,
     DetectionModel,


### PR DESCRIPTION
Replace ASSERT_TRUE with ASSERT_EQ because it reports the actual values if there's mismatch.

Detection accuracy still diverges.