### PR TITLE
Fix cpp deserialize tests

### DIFF
--- a/model_api/cpp/models/include/models/classification_model.h
+++ b/model_api/cpp/models/include/models/classification_model.h
@@ -50,7 +50,6 @@ protected:
 
     void prepareInputsOutputs(std::shared_ptr<ov::Model>& model) override;
     void updateModelInfo() override;
-    void addOrFindSoftmaxAndTopkOutputs();
     std::unique_ptr<ResultBase> get_multilabel_predictions(InferenceResult& infResult);
     std::unique_ptr<ResultBase> get_multiclass_predictions(InferenceResult& infResult);
 };

--- a/tests/cpp/accuracy/test_accuracy.cpp
+++ b/tests/cpp/accuracy/test_accuracy.cpp
@@ -81,14 +81,14 @@ TEST_P(ModelParameterizedTest, AccuracyTest)
     std::string modelPath;
     const std::string& name = modelData.name;
     if (name.substr(name.size() - 4) == ".xml") {
-        modelPath = name;
+        modelPath = DATA_DIR + '/' + name;
     } else {
-        modelPath = string_format(MODEL_PATH_TEMPLATE, name.c_str(), name.c_str());
+        modelPath = DATA_DIR + '/' + string_format(MODEL_PATH_TEMPLATE, name.c_str(), name.c_str());
     }
     const std::string& basename = modelPath.substr(modelPath.find_last_of("/\\") + 1);
     for (const std::string& modelXml: {modelPath, DATA_DIR + "/serialized/" + basename}) {
         if (modelData.type == "DetectionModel") {
-            auto model = DetectionModel::create_model(DATA_DIR + "/" + modelPath);
+            auto model = DetectionModel::create_model(modelXml);
 
             for (size_t i = 0; i < modelData.testData.size(); i++) {
                 auto imagePath = DATA_DIR + "/" + modelData.testData[i].image;
@@ -110,7 +110,7 @@ TEST_P(ModelParameterizedTest, AccuracyTest)
             }
         }
         else if (modelData.type == "ClassificationModel") {
-            auto model = ClassificationModel::create_model(DATA_DIR + "/" + modelPath);
+            auto model = ClassificationModel::create_model(modelXml);
 
             for (size_t i = 0; i < modelData.testData.size(); i++) {
                 auto imagePath = DATA_DIR + "/" + modelData.testData[i].image;
@@ -131,7 +131,7 @@ TEST_P(ModelParameterizedTest, AccuracyTest)
             }
         }
         else if (modelData.type == "SegmentationModel") {
-            auto model = SegmentationModel::create_model(DATA_DIR + "/" + modelPath);
+            auto model = SegmentationModel::create_model(modelXml);
 
             for (size_t i = 0; i < modelData.testData.size(); i++) {
                 auto imagePath = DATA_DIR + "/" + modelData.testData[i].image;


### PR DESCRIPTION
It turns out we didn't actually test C++ deserialization.
Enabling it revealed that Classification is missaligned.
Updated Python version. That requires ov.Model modification which prohibits OVMS serving case,
but it seems we already lost this feature after we added inference_adapter.embed_preprocessing to ImageModel.

Merge after https://github.com/openvinotoolkit/model_api/pull/52