### PR TITLE
Remove bool workaround for set_rt_info()

### DIFF
--- a/model_api/cpp/models/src/classification_model.cpp
+++ b/model_api/cpp/models/src/classification_model.cpp
@@ -197,13 +197,9 @@ void ClassificationModel::updateModelInfo() {
 
     model->set_rt_info(ClassificationModel::ModelType, "model_info", "model_type");
     model->set_rt_info(topk, "model_info", "topk");
-
-    auto bool_to_string = [](bool b) -> std::string {
-        return b ? "True" : "False";
-    };
-    model->set_rt_info(bool_to_string(multilabel), "model_info", "multilabel");
-    model->set_rt_info(bool_to_string(hierarchical), "model_info", "hierarchical");
-    model->set_rt_info(bool_to_string(output_raw_scores), "model_info", "output_raw_scores");
+    model->set_rt_info(multilabel, "model_info", "multilabel");
+    model->set_rt_info(hierarchical, "model_info", "hierarchical");
+    model->set_rt_info(output_raw_scores, "model_info", "output_raw_scores");
     model->set_rt_info(confidence_threshold, "model_info", "confidence_threshold");
 }
 


### PR DESCRIPTION
For get_rt_info() there's already a parser accepting OpenVINO bool representation and True/False. So we can allow OpenVINO to store bools as it wishes.