### PR TITLE
Reduce cmake_minimum version back to 3.10

### DIFF
--- a/model_api/cpp/CMakeLists.txt
+++ b/model_api/cpp/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.10)
 
 # Multi config generators such as Visual Studio ignore CMAKE_BUILD_TYPE. Multi config generators are configured with
 # CMAKE_CONFIGURATION_TYPES, but limiting options in it completely removes such build options
@@ -51,7 +51,6 @@ source_group("adapters/include" FILES ${ADAPTERS_HEADERS})
 add_library(model_api STATIC ${MODELS_SOURCES} ${UTILS_SOURCES} ${ADAPTERS_SOURCES})
 target_include_directories(model_api PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/models/include>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/utils/include>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/adapters/include>" "$<INSTALL_INTERFACE:include>")
 target_link_libraries(model_api PUBLIC openvino::runtime opencv_core opencv_imgproc)
-target_link_libraries(model_api PRIVATE $<BUILD_LOCAL_INTERFACE:nlohmann_json::nlohmann_json>)
 set_target_properties(model_api PROPERTIES CXX_STANDARD 17)
 set_target_properties(model_api PROPERTIES CMAKE_CXX_STANDARD_REQUIRED ON)
 if(MSVC)


### PR DESCRIPTION
Mediapipe and bazel (rules_foreign_cc) cannot handle that high of a cmake version. Mediapipe  uses rules_foreign_cc to build model_api and the highest cmake currently supported in rules_foreign_cc(0.9) is 3.23. Cmake 3.23 does not implement BUILD_LOCAL_INTERFACE used in model_api.

Can we reduce the cmake_minimum version back to 3.10?
And can we skip the target_link_libraries for json?

