### PR TITLE
Fix Anomaly Classification

### DIFF
--- a/model_api/cpp/models/src/anomaly_model.cpp
+++ b/model_api/cpp/models/src/anomaly_model.cpp
@@ -77,12 +77,11 @@ std::unique_ptr<ResultBase> AnomalyModel::postprocess(InferenceResult& infResult
     }
     pred_label = labels[pred_score > imageThreshold ? 1 : 0];
 
-    if (task == "segmentation" || task == "detection") {
-        pred_mask = anomaly_map >= pixelThreshold;
-        pred_mask.convertTo(pred_mask, CV_8UC1, 1 / 255.);
-        cv::resize(pred_mask, pred_mask, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});
-        anomaly_map = normalize(anomaly_map, pixelThreshold);
-    }
+    pred_mask = anomaly_map >= pixelThreshold;
+    pred_mask.convertTo(pred_mask, CV_8UC1, 1 / 255.);
+    cv::resize(pred_mask, pred_mask, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});
+    anomaly_map = normalize(anomaly_map, pixelThreshold);
+
     pred_score = normalize(pred_score, imageThreshold);
     if (!anomaly_map.empty()) {
         cv::resize(anomaly_map, anomaly_map, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});

--- a/model_api/cpp/models/src/anomaly_model.cpp
+++ b/model_api/cpp/models/src/anomaly_model.cpp
@@ -85,6 +85,8 @@ std::unique_ptr<ResultBase> AnomalyModel::postprocess(InferenceResult& infResult
     pred_score = normalize(pred_score, imageThreshold);
     if (!anomaly_map.empty()) {
         cv::resize(anomaly_map, anomaly_map, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});
+    }
+    if (!pred_mask.empty()) {
         cv::resize(pred_mask, pred_mask, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});
     }
     if (task == "detection") {

--- a/model_api/cpp/models/src/anomaly_model.cpp
+++ b/model_api/cpp/models/src/anomaly_model.cpp
@@ -80,14 +80,12 @@ std::unique_ptr<ResultBase> AnomalyModel::postprocess(InferenceResult& infResult
     if (task == "segmentation" || task == "detection") {
         pred_mask = anomaly_map >= pixelThreshold;
         pred_mask.convertTo(pred_mask, CV_8UC1, 1 / 255.);
+        cv::resize(pred_mask, pred_mask, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});
         anomaly_map = normalize(anomaly_map, pixelThreshold);
     }
     pred_score = normalize(pred_score, imageThreshold);
     if (!anomaly_map.empty()) {
         cv::resize(anomaly_map, anomaly_map, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});
-    }
-    if (!pred_mask.empty()) {
-        cv::resize(pred_mask, pred_mask, cv::Size{inputImgSize.inputImgWidth, inputImgSize.inputImgHeight});
     }
     if (task == "detection") {
         pred_boxes = getBoxes(pred_mask);

--- a/model_api/python/openvino/model_api/models/anomaly.py
+++ b/model_api/python/openvino/model_api/models/anomaly.py
@@ -67,13 +67,12 @@ class AnomalyDetection(ImageModel):
             self.labels[1] if pred_score > self.image_threshold else self.labels[0]
         )
 
-        if self.task in ("segmentation", "detection"):
-            assert anomaly_map is not None
-            pred_mask = (anomaly_map >= self.pixel_threshold).astype(np.uint8)
-            anomaly_map = self._normalize(anomaly_map, self.pixel_threshold)
-            pred_mask = cv2.resize(
-                pred_mask, (meta["original_shape"][1], meta["original_shape"][0])
-            )
+        assert anomaly_map is not None
+        pred_mask = (anomaly_map >= self.pixel_threshold).astype(np.uint8)
+        anomaly_map = self._normalize(anomaly_map, self.pixel_threshold)
+        pred_mask = cv2.resize(
+            pred_mask, (meta["original_shape"][1], meta["original_shape"][0])
+        )
 
         # normalize
         pred_score = self._normalize(pred_score, self.image_threshold)

--- a/model_api/python/openvino/model_api/models/anomaly.py
+++ b/model_api/python/openvino/model_api/models/anomaly.py
@@ -71,17 +71,17 @@ class AnomalyDetection(ImageModel):
             assert anomaly_map is not None
             pred_mask = (anomaly_map >= self.pixel_threshold).astype(np.uint8)
             anomaly_map = self._normalize(anomaly_map, self.pixel_threshold)
+            pred_mask = cv2.resize(
+                pred_mask, (meta["original_shape"][1], meta["original_shape"][0])
+            )
 
         # normalize
         pred_score = self._normalize(pred_score, self.image_threshold)
 
         # resize outputs
-        if anomaly_map is not None and pred_mask is not None:
+        if anomaly_map is not None:
             anomaly_map = cv2.resize(
                 anomaly_map, (meta["original_shape"][1], meta["original_shape"][0])
-            )
-            pred_mask = cv2.resize(
-                pred_mask, (meta["original_shape"][1], meta["original_shape"][0])
             )
 
         if self.task == "detection":

--- a/model_api/python/openvino/model_api/models/utils.py
+++ b/model_api/python/openvino/model_api/models/utils.py
@@ -37,15 +37,9 @@ class AnomalyResult(NamedTuple):
         return tensor.min(), tensor.max()
 
     def __str__(self) -> str:
-        assert self.anomaly_map is not None
-        assert self.pred_mask is not None
-        anomaly_map_min, anomaly_map_max = self._compute_min_max(self.anomaly_map)
-        pred_mask_min, pred_mask_max = self._compute_min_max(self.pred_mask)
         return (
-            f"anomaly_map min:{anomaly_map_min:.3f} max:{anomaly_map_max};"
             f"pred_score:{self.pred_score};"
             f"pred_label:{self.pred_label};"
-            f"pred_mask min:{pred_mask_min} max:{pred_mask_max};"
         )
 
 

--- a/model_api/python/openvino/model_api/models/utils.py
+++ b/model_api/python/openvino/model_api/models/utils.py
@@ -37,9 +37,15 @@ class AnomalyResult(NamedTuple):
         return tensor.min(), tensor.max()
 
     def __str__(self) -> str:
+        assert self.anomaly_map is not None
+        assert self.pred_mask is not None
+        anomaly_map_min, anomaly_map_max = self._compute_min_max(self.anomaly_map)
+        pred_mask_min, pred_mask_max = self._compute_min_max(self.pred_mask)
         return (
+            f"anomaly_map min:{anomaly_map_min:.3f} max:{anomaly_map_max};"
             f"pred_score:{self.pred_score};"
             f"pred_label:{self.pred_label};"
+            f"pred_mask min:{pred_mask_min} max:{pred_mask_max};"
         )
 
 


### PR DESCRIPTION
Only for detection and segmentation tasks the anomaly task thresholds the anomaly map.
For classification this causes a cv error since pred_mask is not set.