### PR TITLE
Fix missing model_info when embedding softmax

### DIFF
--- a/model_api/cpp/models/src/classification_model.cpp
+++ b/model_api/cpp/models/src/classification_model.cpp
@@ -118,7 +118,14 @@ void addOrFindSoftmaxAndTopkOutputs(std::shared_ptr<ov::Model>& model, size_t to
             outputs_vector.push_back(output);
         }
     }
+
+    auto source_rt_info = model->has_rt_info("model_info") ? model->get_rt_info<ov::AnyMap>("model_info") : ov::AnyMap{};
     model = std::make_shared<ov::Model>(outputs_vector, model->get_parameters(), "classification");
+
+    // preserve extra model_info items
+    for (const auto& k : source_rt_info) {
+        model->set_rt_info(k.second, "model_info", k.first);
+    }
 
     // manually set output tensors name for created topK node
     model->outputs()[0].set_names({indices_name});

--- a/model_api/python/openvino/model_api/models/classification.py
+++ b/model_api/python/openvino/model_api/models/classification.py
@@ -292,11 +292,18 @@ def addOrFindSoftmaxAndTopkOutputs(inference_adapter, topk, output_raw_scores):
             or _feature_vector_name in output.get_names()
         ):
             results_descr.append(output)
+
+    source_rt_info = inference_adapter.get_model().get_rt_info()
     inference_adapter.model = Model(
         results_descr,
         inference_adapter.model.get_parameters(),
         "classification",
     )
+
+    if "model_info" in source_rt_info:
+        source_rt_info = source_rt_info["model_info"]
+    for k in source_rt_info:
+        inference_adapter.model.set_rt_info(source_rt_info[k], ["model_info", k])
 
     # manually set output tensors name for created topK node
     inference_adapter.model.outputs[0].tensor.set_names({"scores"})

--- a/tests/python/accuracy/public_scope.json
+++ b/tests/python/accuracy/public_scope.json
@@ -194,6 +194,7 @@
     {
         "name": "otx_models/cls_mobilenetv3_large_cars.xml",
         "type": "ClassificationModel",
+        "check_extra_rt_info": "True",
         "test_data": [
             {
                 "image": "coco128/images/train2017/000000000471.jpg",

--- a/tests/python/accuracy/test_accuracy.py
+++ b/tests/python/accuracy/test_accuracy.py
@@ -187,6 +187,12 @@ def test_image_models(data, dump, result, model_data):
             model.get_model().save(data + "/serialized/" + save_name)
         else:
             model.save(data + "/serialized/" + save_name)
+            if model_data.get("check_extra_rt_info", False):
+                assert (
+                    create_models.core.read_model(data + "/serialized/" + save_name)
+                    .get_rt_info(["model_info", "label_ids"])
+                    .astype(str)
+                )
 
     if dump:
         result[-1]["test_data"] = inference_results


### PR DESCRIPTION
# What does this PR do?
model_info is forwarded to the new model in addOrFindSoftmaxAndTopkOutputs




<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
