### PR TITLE
Use output itself rather than index for unnamed outputs

### DIFF
--- a/model_api/python/openvino/model_api/adapters/openvino_adapter.py
+++ b/model_api/python/openvino/model_api/adapters/openvino_adapter.py
@@ -278,7 +278,7 @@ class OpenvinoAdapter(InferenceAdapter):
                 else output.shape
             )
 
-            output_name = output.get_any_name() if output.get_names() else i
+            output_name = output.get_any_name() if output.get_names() else output
             outputs[output_name] = Metadata(
                 output.get_names(),
                 list(output_shape),


### PR DESCRIPTION
# What does this PR do?

Accessing the output node is more correct, since the only supported by `get_tensor()` types are:
    1. (self: openvino._pyopenvino.InferRequest, name: str) -> openvino._pyopenvino.Tensor
    2. (self: openvino._pyopenvino.InferRequest, port: openvino._pyopenvino.ConstOutput) -> openvino._pyopenvino.Tensor
    3. (self: openvino._pyopenvino.InferRequest, port: openvino._pyopenvino.Output) -> openvino._pyopenvino.Tensor

Previously, that worked because cls model replaces outputs, so avoiding a error in the constructor was enough

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
