### PR TITLE
Don't rely on outputs order from adapter in cls wrapper

### DIFF
--- a/model_api/cpp/models/src/classification_model.cpp
+++ b/model_api/cpp/models/src/classification_model.cpp
@@ -434,7 +434,7 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
                                                   inputShape[ov::layout::height_idx(inputLayout)]},
                                         pad_value,
                                         reverse_input_channels,
-                                        {},
+                                        mean_values,
                                         scale_values);
 
         ov::preprocess::PrePostProcessor ppp = ov::preprocess::PrePostProcessor(model);

--- a/tests/python/accuracy/prepare_data.py
+++ b/tests/python/accuracy/prepare_data.py
@@ -109,6 +109,7 @@ async def main():
             download_otx_model(client, otx_models_dir, "anomaly_padim_bottle_mvtec"),
             download_otx_model(client, otx_models_dir, "anomaly_stfpm_bottle_mvtec"),
             download_otx_model(client, otx_models_dir, "deit-tiny"),
+            download_otx_model(client, otx_models_dir, "cls_efficient_b0_shuffled_outputs"),
         )
 
 

--- a/tests/python/accuracy/prepare_data.py
+++ b/tests/python/accuracy/prepare_data.py
@@ -109,7 +109,9 @@ async def main():
             download_otx_model(client, otx_models_dir, "anomaly_padim_bottle_mvtec"),
             download_otx_model(client, otx_models_dir, "anomaly_stfpm_bottle_mvtec"),
             download_otx_model(client, otx_models_dir, "deit-tiny"),
-            download_otx_model(client, otx_models_dir, "cls_efficient_b0_shuffled_outputs"),
+            download_otx_model(
+                client, otx_models_dir, "cls_efficient_b0_shuffled_outputs"
+            ),
         )
 
 

--- a/tests/python/accuracy/public_scope.json
+++ b/tests/python/accuracy/public_scope.json
@@ -224,6 +224,16 @@
         ]
     },
     {
+        "name": "otx_models/cls_efficient_b0_shuffled_outputs.xml",
+        "type": "ClassificationModel",
+        "test_data": [
+            {
+                "image": "coco128/images/train2017/000000000471.jpg",
+                "reference": ["3 (Non-Rigid): 0.503, 4 (Circle): 0.943, 5 (Lion): 0.969, 6 (Panda): 0.988, [1,7,7,7], [1,7], [0]"]
+            }
+        ]
+    },
+    {
         "name": "otx_models/cls_efficient_v2s_cars.xml",
         "type": "ClassificationModel",
         "test_data": [


### PR DESCRIPTION
# What does this PR do?

OVMS adapter can return the names in an arbitrary order, while the cls wrapper expects logits to be at the first place.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
