### PR TITLE
Return task-specific result type from tilers

### DIFF
--- a/model_api/cpp/models/src/model_base.cpp
+++ b/model_api/cpp/models/src/model_base.cpp
@@ -41,7 +41,12 @@ class TmpCallbackSetter {
         model->setCallback(tmp_callback);
     }
     ~TmpCallbackSetter() {
-        model->setCallback(last_callback);
+        if (last_callback) {
+            model->setCallback(last_callback);
+        }
+        else {
+            model->setCallback([](std::unique_ptr<ResultBase>, const ov::AnyMap&){});
+        }
     }
 };
 }

--- a/model_api/cpp/tilers/include/tilers/detection.h
+++ b/model_api/cpp/tilers/include/tilers/detection.h
@@ -17,16 +17,19 @@
 #pragma once
 #include <tilers/tiler_base.h>
 
+struct DetectionResult;
 
 class DetectionTiler : public TilerBase {
 public:
     DetectionTiler(const std::shared_ptr<ImageModel>& model, const ov::AnyMap& configuration);
     virtual ~DetectionTiler() = default;
 
+    virtual std::unique_ptr<DetectionResult> run(const ImageInputData& inputData);
+
 protected:
     virtual std::unique_ptr<ResultBase> postprocess_tile(std::unique_ptr<ResultBase>, const cv::Rect&);
     virtual std::unique_ptr<ResultBase> merge_results(const std::vector<std::unique_ptr<ResultBase>>&, const cv::Size&, const std::vector<cv::Rect>&);
     ov::Tensor merge_saliency_maps(const std::vector<std::unique_ptr<ResultBase>>&, const cv::Size&, const std::vector<cv::Rect>&);
 
-    size_t max_pred_number = 100;
+    size_t max_pred_number = 200;
 };

--- a/model_api/cpp/tilers/include/tilers/instance_segmentation.h
+++ b/model_api/cpp/tilers/include/tilers/instance_segmentation.h
@@ -15,14 +15,15 @@
 */
 
 #pragma once
-#include <tilers/detection.h>
+#include <tilers/tiler_base.h>
 
+struct InstanceSegmentationResult;
 
-class InstanceSegmentationTiler : public DetectionTiler {
+class InstanceSegmentationTiler : public TilerBase {
     /*InstanceSegmentationTiler tiler works with MaskRCNNModel model only*/
 public:
     InstanceSegmentationTiler(std::shared_ptr<ImageModel> model, const ov::AnyMap& configuration);
-    virtual std::unique_ptr<ResultBase> run(const ImageInputData& inputData);
+    virtual std::unique_ptr<InstanceSegmentationResult> run(const ImageInputData& inputData);
     virtual ~InstanceSegmentationTiler() = default;
     bool postprocess_semantic_masks = true;
 
@@ -31,4 +32,6 @@ protected:
     virtual std::unique_ptr<ResultBase> merge_results(const std::vector<std::unique_ptr<ResultBase>>&, const cv::Size&, const std::vector<cv::Rect>&);
 
     std::vector<cv::Mat_<std::uint8_t>> merge_saliency_maps(const std::vector<std::unique_ptr<ResultBase>>&, const cv::Size&, const std::vector<cv::Rect>&);
+
+    size_t max_pred_number = 200;
 };

--- a/model_api/cpp/tilers/include/tilers/tiler_base.h
+++ b/model_api/cpp/tilers/include/tilers/tiler_base.h
@@ -37,10 +37,10 @@ public:
 
     virtual ~TilerBase() = default;
 
-    virtual std::unique_ptr<ResultBase> run(const ImageInputData& inputData);
 
 protected:
 
+    virtual std::unique_ptr<ResultBase> run_impl(const ImageInputData& inputData);
     std::vector<cv::Rect> tile(const cv::Size&);
     std::vector<cv::Rect> filter_tiles(const cv::Mat&, const std::vector<cv::Rect>&);
     std::unique_ptr<ResultBase> predict_sync(const cv::Mat&, const std::vector<cv::Rect>&);

--- a/model_api/cpp/tilers/src/detection.cpp
+++ b/model_api/cpp/tilers/src/detection.cpp
@@ -51,13 +51,7 @@ DetectionTiler::DetectionTiler(const std::shared_ptr<ImageModel>& _model, const 
         extra_config = model->getInferenceAdapter()->getModelConfig();
     }
 
-    ov::AnyMap merged_config(configuration);
-    merged_config.merge(extra_config);
-
-    auto max_pred_iter = merged_config.find("max_pred_number");
-    if (max_pred_iter != merged_config.end()) {
-        max_pred_number = max_pred_iter->second.as<size_t>();
-    }
+    max_pred_number = get_from_any_maps("max_pred_number", configuration, extra_config, max_pred_number);
 }
 
 std::unique_ptr<ResultBase> DetectionTiler::postprocess_tile(std::unique_ptr<ResultBase> tile_result, const cv::Rect& coord) {
@@ -99,7 +93,7 @@ std::unique_ptr<ResultBase> DetectionTiler::merge_results(const std::vector<std:
         }
     }
 
-    auto keep_idx = multiclass_nms(all_detections, all_scores, iou_threshold, false, 200);
+    auto keep_idx = multiclass_nms(all_detections, all_scores, iou_threshold, false, max_pred_number);
 
     result->objects.reserve(keep_idx.size());
     for (auto idx : keep_idx) {
@@ -223,4 +217,9 @@ ov::Tensor DetectionTiler::merge_saliency_maps(const std::vector<std::unique_ptr
     }
 
     return merged_map;
+}
+
+std::unique_ptr<DetectionResult> DetectionTiler::run(const ImageInputData& inputData) {
+    auto result = this->run_impl(inputData);
+    return std::unique_ptr<DetectionResult>(static_cast<DetectionResult*>(result.release()));
 }

--- a/model_api/cpp/tilers/src/tiler_base.cpp
+++ b/model_api/cpp/tilers/src/tiler_base.cpp
@@ -116,7 +116,7 @@ cv::Mat TilerBase::crop_tile(const cv::Mat& image, const cv::Rect& coord) {
     return cv::Mat(image, coord);
 }
 
-std::unique_ptr<ResultBase> TilerBase::run(const ImageInputData& inputData) {
+std::unique_ptr<ResultBase> TilerBase::run_impl(const ImageInputData& inputData) {
     auto& image = inputData.inputImage;
     auto tile_coords = tile(image.size());
     tile_coords = filter_tiles(image, tile_coords);


### PR DESCRIPTION
# What does this PR do?

- Tilers now return wrapper-specific results, instead of `ResultBase`
- Fix possible call of empty function when a custom callback was not set before batch inference
