### PR TITLE
Skip tiled saliency map merging if only one map is available

### DIFF
--- a/model_api/cpp/tilers/src/detection.cpp
+++ b/model_api/cpp/tilers/src/detection.cpp
@@ -146,7 +146,7 @@ ov::Tensor DetectionTiler::merge_saliency_maps(const std::vector<std::unique_ptr
         image_saliency_map = all_saliency_maps[0];
     }
 
-    if (image_saliency_map.get_size() == 1) {
+    if ((image_saliency_map.get_size() == 1) || (all_saliency_maps.size() == 1)) {
         return image_saliency_map;
     }
 

--- a/model_api/python/model_api/tilers/detection.py
+++ b/model_api/python/model_api/tilers/detection.py
@@ -164,7 +164,7 @@ class DetectionTiler(Tiler):
 
         image_saliency_map = saliency_maps[0]
 
-        if len(image_saliency_map.shape) == 1:
+        if len(image_saliency_map.shape) == 1 or len(saliency_maps) == 1:
             return image_saliency_map
 
         recover_shape = False


### PR DESCRIPTION
# What does this PR do?

Tile merging: detection.
If only one tiled saliency map for merging, skip the calculation.

Align with OTX to pass integration tests which fail because of different size of merged tiled saliency maps.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
