### PR TITLE
[python] Add batch inference emulation 

### DIFF
--- a/model_api/python/model_api/models/keypoint_detection.py
+++ b/model_api/python/model_api/models/keypoint_detection.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-from model_api.pipelines import AsyncPipeline
 
 from .image_model import ImageModel
 from .types import ListValue
@@ -87,7 +86,6 @@ class TopDownKeypointDetectionPipeline:
 
     def __init__(self, base_model: KeypointDetectionModel) -> None:
         self.base_model = base_model
-        self.async_pipeline = AsyncPipeline(self.base_model)
 
     def predict(
         self, image: np.ndarray, detections: list[Detection]
@@ -125,17 +123,7 @@ class TopDownKeypointDetectionPipeline:
         Returns:
             list[DetectedKeypoints]: per crop keypoints
         """
-        for i, crop in enumerate(crops):
-            self.async_pipeline.submit_data(crop, i)
-        self.async_pipeline.await_all()
-
-        num_crops = len(crops)
-        result = []
-        for j in range(num_crops):
-            crop_prediction, _ = self.async_pipeline.get_result(j)
-            result.append(crop_prediction)
-
-        return result
+        return self.base_model.infer_batch(crops)
 
 
 def _decode_simcc(

--- a/model_api/python/model_api/models/model.py
+++ b/model_api/python/model_api/models/model.py
@@ -419,8 +419,10 @@ class Model:
         @contextmanager
         def tmp_callback(*args, **kwds):
             old_callback = self.callback_fn
+
             def batch_infer_callback(result, id):
                 completed_results[id] = result
+
             try:
                 self.set_callback(batch_infer_callback)
                 yield

--- a/model_api/python/model_api/models/model.py
+++ b/model_api/python/model_api/models/model.py
@@ -419,7 +419,7 @@ class Model:
         completed_results = {}
 
         @contextmanager
-        def tmp_callback(*args, **kwds):
+        def tmp_callback():
             old_callback = self.callback_fn
 
             def batch_infer_callback(result, id):

--- a/model_api/python/model_api/models/model.py
+++ b/model_api/python/model_api/models/model.py
@@ -414,6 +414,8 @@ class Model:
         Returns:
             list: a list of inference results
         """
+        self.await_all()
+
         completed_results = {}
 
         @contextmanager

--- a/model_api/python/model_api/models/model.py
+++ b/model_api/python/model_api/models/model.py
@@ -14,9 +14,9 @@
  limitations under the License.
 """
 
-from contextlib import contextmanager
 import logging as log
 import re
+from contextlib import contextmanager
 
 from model_api.adapters.inference_adapter import InferenceAdapter
 from model_api.adapters.onnx_adapter import ONNXRuntimeAdapter


### PR DESCRIPTION
Batch inference emulation is done by enqueuing batch items for async inference.

That design allows to avoid usage of AsyncPipeline, simplifying batch processing for end users.
However, if obtaining every batch element is somehow expensive, AsyncPipeline allows to squeeze more performance by running infer requests in parallel to preparation of the next batch elements.