### PR TITLE
Adjust cpp inference adapters for OVMS

### DIFF
--- a/model_api/cpp/adapters/include/adapters/inference_adapter.h
+++ b/model_api/cpp/adapters/include/adapters/inference_adapter.h
@@ -38,6 +38,7 @@ public:
     virtual ~InferenceAdapter() = default;
 
     virtual InferenceOutput infer(const InferenceInput& input) = 0;
+    virtual void infer(const InferenceInput& input, InferenceOutput& output) = 0;
     virtual void setCallback(std::function<void(ov::InferRequest, CallbackData)> callback) = 0;
     virtual void inferAsync(const InferenceInput& input, CallbackData callback_args) = 0;
     virtual bool isReady() = 0;
@@ -48,6 +49,9 @@ public:
                            const std::string& device = "", const ov::AnyMap& compilationConfig = {},
                            size_t max_num_requests = 0) = 0;
     virtual ov::PartialShape getInputShape(const std::string& inputName) const = 0;
+    virtual ov::PartialShape getOutputShape(const std::string& inputName) const = 0;
+    virtual ov::element::Type_t getInputDatatype(const std::string& inputName) const = 0;
+    virtual ov::element::Type_t getOutputDatatype(const std::string& outputName) const = 0;
     virtual std::vector<std::string> getInputNames() const = 0;
     virtual std::vector<std::string> getOutputNames() const = 0;
     virtual const ov::AnyMap& getModelConfig() const = 0;

--- a/model_api/cpp/adapters/include/adapters/openvino_adapter.h
+++ b/model_api/cpp/adapters/include/adapters/openvino_adapter.h
@@ -32,6 +32,7 @@ public:
     OpenVINOInferenceAdapter() = default;
 
     virtual InferenceOutput infer(const InferenceInput& input) override;
+    virtual void infer(const InferenceInput& input, InferenceOutput& output) override;
     virtual void inferAsync(const InferenceInput& input, const CallbackData callback_args) override;
     virtual void setCallback(std::function<void(ov::InferRequest, const CallbackData)> callback);
     virtual bool isReady();
@@ -42,6 +43,9 @@ public:
                                                     size_t max_num_requests = 1) override;
     virtual size_t getNumAsyncExecutors() const;
     virtual ov::PartialShape getInputShape(const std::string& inputName) const override;
+    virtual ov::PartialShape getOutputShape(const std::string& outputName) const override;
+    virtual ov::element::Type_t getInputDatatype(const std::string& inputName) const override;
+    virtual ov::element::Type_t getOutputDatatype(const std::string& outputName) const override;
     virtual std::vector<std::string> getInputNames() const override;
     virtual std::vector<std::string> getOutputNames() const override;
     virtual const ov::AnyMap& getModelConfig() const override;

--- a/model_api/cpp/adapters/src/openvino_adapter.cpp
+++ b/model_api/cpp/adapters/src/openvino_adapter.cpp
@@ -112,10 +112,10 @@ void OpenVINOInferenceAdapter::initInputsOutputs() {
         outputNames.push_back(output.get_any_name());
     }
 }
-ov::element::Type_t OpenVINOInferenceAdapter::getInputDatatype(const std::string& inputName) const {
+ov::element::Type_t OpenVINOInferenceAdapter::getInputDatatype(const std::string&) const {
     throw std::runtime_error("Not implemented");
 }
-ov::element::Type_t OpenVINOInferenceAdapter::getOutputDatatype(const std::string& outputName) const {
+ov::element::Type_t OpenVINOInferenceAdapter::getOutputDatatype(const std::string&) const {
     throw std::runtime_error("Not implemented");
 }
 

--- a/model_api/cpp/adapters/src/openvino_adapter.cpp
+++ b/model_api/cpp/adapters/src/openvino_adapter.cpp
@@ -49,6 +49,10 @@ void OpenVINOInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>&
     }
 }
 
+void OpenVINOInferenceAdapter::infer(const InferenceInput&, InferenceOutput&) {
+    throw std::runtime_error("Not implemented");
+}
+
 InferenceOutput OpenVINOInferenceAdapter::infer(const InferenceInput& input) {
     auto request = asyncQueue->operator[](asyncQueue->get_idle_request_id());
     // Fill input blobs
@@ -95,6 +99,9 @@ size_t OpenVINOInferenceAdapter::getNumAsyncExecutors() const {
 ov::PartialShape OpenVINOInferenceAdapter::getInputShape(const std::string& inputName) const {
     return compiledModel.input(inputName).get_partial_shape();
 }
+ov::PartialShape OpenVINOInferenceAdapter::getOutputShape(const std::string& outputName) const {
+    return compiledModel.output(outputName).get_shape();
+}
 
 void OpenVINOInferenceAdapter::initInputsOutputs() {
     for (const auto& input : compiledModel.inputs()) {
@@ -104,6 +111,12 @@ void OpenVINOInferenceAdapter::initInputsOutputs() {
     for (const auto& output : compiledModel.outputs()) {
         outputNames.push_back(output.get_any_name());
     }
+}
+ov::element::Type_t OpenVINOInferenceAdapter::getInputDatatype(const std::string& inputName) const {
+    throw std::runtime_error("Not implemented");
+}
+ov::element::Type_t OpenVINOInferenceAdapter::getOutputDatatype(const std::string& outputName) const {
+    throw std::runtime_error("Not implemented");
 }
 
 std::vector<std::string> OpenVINOInferenceAdapter::getInputNames() const {


### PR DESCRIPTION
This is required to allow no-copy inference with Model API within Mediapipe graphs.

Use OVMS C-API with set output to avoid copy in OVMSModelAPIAdapter.

Ticket: CVS-155477

Related changes:
https://github.com/openvinotoolkit/model_server/pull/2763
https://github.com/openvinotoolkit/mediapipe/pull/92

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? OVMS integration tests, are used.
