### PR TITLE
Use new-style license

### DIFF
--- a/examples/cpp/asynchronous_api/main.cpp
+++ b/examples/cpp/asynchronous_api/main.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <adapters/openvino_adapter.h>
 #include <models/detection_model.h>
 #include <models/results.h>

--- a/examples/cpp/asynchronous_api/main.cpp
+++ b/examples/cpp/asynchronous_api/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <adapters/openvino_adapter.h>

--- a/examples/cpp/synchronous_api/main.cpp
+++ b/examples/cpp/synchronous_api/main.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2018-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <models/detection_model.h>
 #include <models/input_data.h>

--- a/examples/cpp/synchronous_api/main.cpp
+++ b/examples/cpp/synchronous_api/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/examples/python/asynchronous_api/run.py
+++ b/examples/python/asynchronous_api/run.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python3
-"""
-Copyright (C) 2018-2022 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import sys
 

--- a/examples/python/asynchronous_api/run.py
+++ b/examples/python/asynchronous_api/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/examples/python/serving_api/run.py
+++ b/examples/python/serving_api/run.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python3
-"""
-Copyright (C) 2018-2022 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import sys
 

--- a/examples/python/serving_api/run.py
+++ b/examples/python/serving_api/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/examples/python/synchronous_api/run.py
+++ b/examples/python/synchronous_api/run.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python3
-"""
-Copyright (C) 2018-2022 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import sys
 

--- a/examples/python/synchronous_api/run.py
+++ b/examples/python/synchronous_api/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/examples/python/visual_prompting/run.py
+++ b/examples/python/visual_prompting/run.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python3
-"""
-Copyright (C) 2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import argparse
 import colorsys

--- a/examples/python/visual_prompting/run.py
+++ b/examples/python/visual_prompting/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/examples/python/zsl_visual_prompting/run.py
+++ b/examples/python/zsl_visual_prompting/run.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python3
-"""
-Copyright (C) 2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import argparse
 import colorsys

--- a/examples/python/zsl_visual_prompting/run.py
+++ b/examples/python/zsl_visual_prompting/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/cpp/adapters/include/adapters/inference_adapter.h
+++ b/model_api/cpp/adapters/include/adapters/inference_adapter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/adapters/include/adapters/inference_adapter.h
+++ b/model_api/cpp/adapters/include/adapters/inference_adapter.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <functional>

--- a/model_api/cpp/adapters/include/adapters/openvino_adapter.h
+++ b/model_api/cpp/adapters/include/adapters/openvino_adapter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/adapters/include/adapters/openvino_adapter.h
+++ b/model_api/cpp/adapters/include/adapters/openvino_adapter.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <functional>

--- a/model_api/cpp/adapters/src/openvino_adapter.cpp
+++ b/model_api/cpp/adapters/src/openvino_adapter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/adapters/src/openvino_adapter.cpp
+++ b/model_api/cpp/adapters/src/openvino_adapter.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "adapters/openvino_adapter.h"
 

--- a/model_api/cpp/models/include/models/anomaly_model.h
+++ b/model_api/cpp/models/include/models/anomaly_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/anomaly_model.h
+++ b/model_api/cpp/models/include/models/anomaly_model.h
@@ -1,18 +1,7 @@
 /*
-  Copyright (C) 2020-2024 Intel Corporation
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include "models/image_model.h"

--- a/model_api/cpp/models/include/models/classification_model.h
+++ b/model_api/cpp/models/include/models/classification_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/classification_model.h
+++ b/model_api/cpp/models/include/models/classification_model.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <stddef.h>

--- a/model_api/cpp/models/include/models/detection_model.h
+++ b/model_api/cpp/models/include/models/detection_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/detection_model.h
+++ b/model_api/cpp/models/include/models/detection_model.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 

--- a/model_api/cpp/models/include/models/detection_model_ext.h
+++ b/model_api/cpp/models/include/models/detection_model_ext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/detection_model_ext.h
+++ b/model_api/cpp/models/include/models/detection_model_ext.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <stddef.h>

--- a/model_api/cpp/models/include/models/detection_model_ssd.h
+++ b/model_api/cpp/models/include/models/detection_model_ssd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/detection_model_ssd.h
+++ b/model_api/cpp/models/include/models/detection_model_ssd.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <stddef.h>

--- a/model_api/cpp/models/include/models/detection_model_yolo.h
+++ b/model_api/cpp/models/include/models/detection_model_yolo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/detection_model_yolo.h
+++ b/model_api/cpp/models/include/models/detection_model_yolo.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <stddef.h>

--- a/model_api/cpp/models/include/models/detection_model_yolov3_onnx.h
+++ b/model_api/cpp/models/include/models/detection_model_yolov3_onnx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/detection_model_yolov3_onnx.h
+++ b/model_api/cpp/models/include/models/detection_model_yolov3_onnx.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2022-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 

--- a/model_api/cpp/models/include/models/detection_model_yolox.h
+++ b/model_api/cpp/models/include/models/detection_model_yolox.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2022-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <memory>

--- a/model_api/cpp/models/include/models/detection_model_yolox.h
+++ b/model_api/cpp/models/include/models/detection_model_yolox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/image_model.h
+++ b/model_api/cpp/models/include/models/image_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/image_model.h
+++ b/model_api/cpp/models/include/models/image_model.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <stddef.h>

--- a/model_api/cpp/models/include/models/input_data.h
+++ b/model_api/cpp/models/include/models/input_data.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <opencv2/opencv.hpp>

--- a/model_api/cpp/models/include/models/input_data.h
+++ b/model_api/cpp/models/include/models/input_data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/instance_segmentation.h
+++ b/model_api/cpp/models/include/models/instance_segmentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/instance_segmentation.h
+++ b/model_api/cpp/models/include/models/instance_segmentation.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writingb  software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <memory>

--- a/model_api/cpp/models/include/models/internal_model_data.h
+++ b/model_api/cpp/models/include/models/internal_model_data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/internal_model_data.h
+++ b/model_api/cpp/models/include/models/internal_model_data.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 

--- a/model_api/cpp/models/include/models/keypoint_detection.h
+++ b/model_api/cpp/models/include/models/keypoint_detection.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <memory>

--- a/model_api/cpp/models/include/models/keypoint_detection.h
+++ b/model_api/cpp/models/include/models/keypoint_detection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/model_base.h
+++ b/model_api/cpp/models/include/models/model_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/model_base.h
+++ b/model_api/cpp/models/include/models/model_base.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <adapters/inference_adapter.h>

--- a/model_api/cpp/models/include/models/results.h
+++ b/model_api/cpp/models/include/models/results.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <map>

--- a/model_api/cpp/models/include/models/results.h
+++ b/model_api/cpp/models/include/models/results.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/segmentation_model.h
+++ b/model_api/cpp/models/include/models/segmentation_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/include/models/segmentation_model.h
+++ b/model_api/cpp/models/include/models/segmentation_model.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <memory>

--- a/model_api/cpp/models/src/anomaly_model.cpp
+++ b/model_api/cpp/models/src/anomaly_model.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/anomaly_model.cpp
+++ b/model_api/cpp/models/src/anomaly_model.cpp
@@ -1,18 +1,7 @@
 /*
-  Copyright (C) 2020-2024 Intel Corporation
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/anomaly_model.h"
 

--- a/model_api/cpp/models/src/classification_model.cpp
+++ b/model_api/cpp/models/src/classification_model.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/classification_model.cpp
+++ b/model_api/cpp/models/src/classification_model.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/classification_model.h"
 

--- a/model_api/cpp/models/src/detection_model.cpp
+++ b/model_api/cpp/models/src/detection_model.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/detection_model.cpp
+++ b/model_api/cpp/models/src/detection_model.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/detection_model.h"
 

--- a/model_api/cpp/models/src/detection_model_ext.cpp
+++ b/model_api/cpp/models/src/detection_model_ext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "models/detection_model_ext.h"

--- a/model_api/cpp/models/src/detection_model_ext.cpp
+++ b/model_api/cpp/models/src/detection_model_ext.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include "models/detection_model_ext.h"
 
 #include <fstream>

--- a/model_api/cpp/models/src/detection_model_ssd.cpp
+++ b/model_api/cpp/models/src/detection_model_ssd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/detection_model_ssd.cpp
+++ b/model_api/cpp/models/src/detection_model_ssd.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/detection_model_ssd.h"
 

--- a/model_api/cpp/models/src/detection_model_yolo.cpp
+++ b/model_api/cpp/models/src/detection_model_yolo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/detection_model_yolo.cpp
+++ b/model_api/cpp/models/src/detection_model_yolo.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/detection_model_yolo.h"
 

--- a/model_api/cpp/models/src/detection_model_yolov3_onnx.cpp
+++ b/model_api/cpp/models/src/detection_model_yolov3_onnx.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/detection_model_yolov3_onnx.cpp
+++ b/model_api/cpp/models/src/detection_model_yolov3_onnx.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2022-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/detection_model_yolov3_onnx.h"
 

--- a/model_api/cpp/models/src/detection_model_yolox.cpp
+++ b/model_api/cpp/models/src/detection_model_yolox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/detection_model_yolox.cpp
+++ b/model_api/cpp/models/src/detection_model_yolox.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2022-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/detection_model_yolox.h"
 

--- a/model_api/cpp/models/src/image_model.cpp
+++ b/model_api/cpp/models/src/image_model.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/image_model.cpp
+++ b/model_api/cpp/models/src/image_model.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/image_model.h"
 

--- a/model_api/cpp/models/src/instance_segmentation.cpp
+++ b/model_api/cpp/models/src/instance_segmentation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/instance_segmentation.cpp
+++ b/model_api/cpp/models/src/instance_segmentation.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/instance_segmentation.h"
 

--- a/model_api/cpp/models/src/keypoint_detection.cpp
+++ b/model_api/cpp/models/src/keypoint_detection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/keypoint_detection.cpp
+++ b/model_api/cpp/models/src/keypoint_detection.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/keypoint_detection.h"
 

--- a/model_api/cpp/models/src/model_base.cpp
+++ b/model_api/cpp/models/src/model_base.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/model_base.h"
 

--- a/model_api/cpp/models/src/model_base.cpp
+++ b/model_api/cpp/models/src/model_base.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/models/src/segmentation_model.cpp
+++ b/model_api/cpp/models/src/segmentation_model.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2020-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "models/segmentation_model.h"
 

--- a/model_api/cpp/models/src/segmentation_model.cpp
+++ b/model_api/cpp/models/src/segmentation_model.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/include/tilers/detection.h
+++ b/model_api/cpp/tilers/include/tilers/detection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/include/tilers/detection.h
+++ b/model_api/cpp/tilers/include/tilers/detection.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2023-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <tilers/tiler_base.h>

--- a/model_api/cpp/tilers/include/tilers/instance_segmentation.h
+++ b/model_api/cpp/tilers/include/tilers/instance_segmentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/include/tilers/instance_segmentation.h
+++ b/model_api/cpp/tilers/include/tilers/instance_segmentation.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2023-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <tilers/tiler_base.h>

--- a/model_api/cpp/tilers/include/tilers/semantic_segmentation.h
+++ b/model_api/cpp/tilers/include/tilers/semantic_segmentation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/include/tilers/semantic_segmentation.h
+++ b/model_api/cpp/tilers/include/tilers/semantic_segmentation.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <tilers/tiler_base.h>

--- a/model_api/cpp/tilers/include/tilers/tiler_base.h
+++ b/model_api/cpp/tilers/include/tilers/tiler_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/include/tilers/tiler_base.h
+++ b/model_api/cpp/tilers/include/tilers/tiler_base.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2023-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 #include <models/image_model.h>

--- a/model_api/cpp/tilers/src/detection.cpp
+++ b/model_api/cpp/tilers/src/detection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/src/detection.cpp
+++ b/model_api/cpp/tilers/src/detection.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2023-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <models/results.h>
 #include <tilers/detection.h>

--- a/model_api/cpp/tilers/src/instance_segmentation.cpp
+++ b/model_api/cpp/tilers/src/instance_segmentation.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2023-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <models/instance_segmentation.h>
 #include <models/results.h>

--- a/model_api/cpp/tilers/src/instance_segmentation.cpp
+++ b/model_api/cpp/tilers/src/instance_segmentation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/src/semantic_segmentation.cpp
+++ b/model_api/cpp/tilers/src/semantic_segmentation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/src/semantic_segmentation.cpp
+++ b/model_api/cpp/tilers/src/semantic_segmentation.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <models/results.h>
 #include <models/segmentation_model.h>

--- a/model_api/cpp/tilers/src/tiler_base.cpp
+++ b/model_api/cpp/tilers/src/tiler_base.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/tilers/src/tiler_base.cpp
+++ b/model_api/cpp/tilers/src/tiler_base.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2023-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <models/image_model.h>
 #include <models/input_data.h>

--- a/model_api/cpp/utils/include/utils/image_utils.h
+++ b/model_api/cpp/utils/include/utils/image_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/utils/include/utils/image_utils.h
+++ b/model_api/cpp/utils/include/utils/image_utils.h
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 

--- a/model_api/cpp/utils/src/args_helper.cpp
+++ b/model_api/cpp/utils/src/args_helper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/utils/src/args_helper.cpp
+++ b/model_api/cpp/utils/src/args_helper.cpp
@@ -1,6 +1,7 @@
-// Copyright (C) 2018-2024 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+/*
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "utils/args_helper.hpp"
 

--- a/model_api/cpp/utils/src/async_infer_queue.cpp
+++ b/model_api/cpp/utils/src/async_infer_queue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/utils/src/async_infer_queue.cpp
+++ b/model_api/cpp/utils/src/async_infer_queue.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "utils/async_infer_queue.hpp"
 

--- a/model_api/cpp/utils/src/image_utils.cpp
+++ b/model_api/cpp/utils/src/image_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/utils/src/image_utils.cpp
+++ b/model_api/cpp/utils/src/image_utils.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2021-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "utils/image_utils.h"
 

--- a/model_api/cpp/utils/src/kuhn_munkres.cpp
+++ b/model_api/cpp/utils/src/kuhn_munkres.cpp
@@ -1,6 +1,7 @@
-// Copyright (C) 2018-2024 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
+/*
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <algorithm>
 #include <limits>

--- a/model_api/cpp/utils/src/kuhn_munkres.cpp
+++ b/model_api/cpp/utils/src/kuhn_munkres.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/utils/src/nms.cpp
+++ b/model_api/cpp/utils/src/nms.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/model_api/cpp/utils/src/nms.cpp
+++ b/model_api/cpp/utils/src/nms.cpp
@@ -1,18 +1,7 @@
 /*
-// Copyright (C) 2023-2024 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "utils/nms.hpp"
 

--- a/model_api/python/model_api/__init__.py
+++ b/model_api/python/model_api/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/model_api/python/model_api/__init__.py
+++ b/model_api/python/model_api/__init__.py
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/model_api/python/model_api/adapters/__init__.py
+++ b/model_api/python/model_api/adapters/__init__.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from .onnx_adapter import ONNXRuntimeAdapter
 from .openvino_adapter import OpenvinoAdapter, create_core, get_user_config

--- a/model_api/python/model_api/adapters/__init__.py
+++ b/model_api/python/model_api/adapters/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/adapters/inference_adapter.py
+++ b/model_api/python/model_api/adapters/inference_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/adapters/inference_adapter.py
+++ b/model_api/python/model_api/adapters/inference_adapter.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import abc
 from dataclasses import dataclass, field

--- a/model_api/python/model_api/adapters/onnx_adapter.py
+++ b/model_api/python/model_api/adapters/onnx_adapter.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2023-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import sys
 from functools import partial, reduce

--- a/model_api/python/model_api/adapters/onnx_adapter.py
+++ b/model_api/python/model_api/adapters/onnx_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/adapters/openvino_adapter.py
+++ b/model_api/python/model_api/adapters/openvino_adapter.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import logging as log
 from pathlib import Path

--- a/model_api/python/model_api/adapters/openvino_adapter.py
+++ b/model_api/python/model_api/adapters/openvino_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/adapters/ovms_adapter.py
+++ b/model_api/python/model_api/adapters/ovms_adapter.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import re
 

--- a/model_api/python/model_api/adapters/ovms_adapter.py
+++ b/model_api/python/model_api/adapters/ovms_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/adapters/utils.py
+++ b/model_api/python/model_api/adapters/utils.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2022-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
 

--- a/model_api/python/model_api/adapters/utils.py
+++ b/model_api/python/model_api/adapters/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/__init__.py
+++ b/model_api/python/model_api/models/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/__init__.py
+++ b/model_api/python/model_api/models/__init__.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from .action_classification import ActionClassificationModel
 from .anomaly import AnomalyDetection

--- a/model_api/python/model_api/models/action_classification.py
+++ b/model_api/python/model_api/models/action_classification.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/action_classification.py
+++ b/model_api/python/model_api/models/action_classification.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations
 

--- a/model_api/python/model_api/models/anomaly.py
+++ b/model_api/python/model_api/models/anomaly.py
@@ -1,20 +1,10 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 """Definition for anomaly models.
 
 Note: This file will change when anomalib is upgraded in OTX. CVS-114640
-
- Copyright (c) 2021-2024 Intel Corporation
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
 """
 
 from __future__ import annotations

--- a/model_api/python/model_api/models/anomaly.py
+++ b/model_api/python/model_api/models/anomaly.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 """Definition for anomaly models.

--- a/model_api/python/model_api/models/classification.py
+++ b/model_api/python/model_api/models/classification.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
 

--- a/model_api/python/model_api/models/classification.py
+++ b/model_api/python/model_api/models/classification.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/detection_model.py
+++ b/model_api/python/model_api/models/detection_model.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from .image_model import ImageModel
 from .types import ListValue, NumericalValue, StringValue

--- a/model_api/python/model_api/models/detection_model.py
+++ b/model_api/python/model_api/models/detection_model.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/image_model.py
+++ b/model_api/python/model_api/models/image_model.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from model_api.adapters.utils import RESIZE_TYPES, InputTransform
 

--- a/model_api/python/model_api/models/image_model.py
+++ b/model_api/python/model_api/models/image_model.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/instance_segmentation.py
+++ b/model_api/python/model_api/models/instance_segmentation.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2020-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import cv2
 import numpy as np

--- a/model_api/python/model_api/models/instance_segmentation.py
+++ b/model_api/python/model_api/models/instance_segmentation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/keypoint_detection.py
+++ b/model_api/python/model_api/models/keypoint_detection.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations
 

--- a/model_api/python/model_api/models/keypoint_detection.py
+++ b/model_api/python/model_api/models/keypoint_detection.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/model.py
+++ b/model_api/python/model_api/models/model.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2020-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import logging as log
 import re

--- a/model_api/python/model_api/models/model.py
+++ b/model_api/python/model_api/models/model.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/sam_models.py
+++ b/model_api/python/model_api/models/sam_models.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
 

--- a/model_api/python/model_api/models/sam_models.py
+++ b/model_api/python/model_api/models/sam_models.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/segmentation.py
+++ b/model_api/python/model_api/models/segmentation.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2020-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
 

--- a/model_api/python/model_api/models/segmentation.py
+++ b/model_api/python/model_api/models/segmentation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/ssd.py
+++ b/model_api/python/model_api/models/ssd.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/ssd.py
+++ b/model_api/python/model_api/models/ssd.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2020-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import numpy as np
 

--- a/model_api/python/model_api/models/types.py
+++ b/model_api/python/model_api/models/types.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2021-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 
 class ConfigurableValueError(ValueError):

--- a/model_api/python/model_api/models/types.py
+++ b/model_api/python/model_api/models/types.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/utils.py
+++ b/model_api/python/model_api/models/utils.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2020-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
 

--- a/model_api/python/model_api/models/utils.py
+++ b/model_api/python/model_api/models/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/visual_prompting.py
+++ b/model_api/python/model_api/models/visual_prompting.py
@@ -1,14 +1,7 @@
-"""Copyright (C) 2024 Intel Corporation
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
 

--- a/model_api/python/model_api/models/visual_prompting.py
+++ b/model_api/python/model_api/models/visual_prompting.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/models/yolo.py
+++ b/model_api/python/model_api/models/yolo.py
@@ -1,14 +1,7 @@
-"""Copyright (C) 2020-2024 Intel Corporation
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from collections import namedtuple
 from itertools import starmap

--- a/model_api/python/model_api/models/yolo.py
+++ b/model_api/python/model_api/models/yolo.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/performance_metrics.py
+++ b/model_api/python/model_api/performance_metrics.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2020-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import logging as log
 from time import perf_counter

--- a/model_api/python/model_api/performance_metrics.py
+++ b/model_api/python/model_api/performance_metrics.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/pipelines/__init__.py
+++ b/model_api/python/model_api/pipelines/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 from .async_pipeline import AsyncPipeline

--- a/model_api/python/model_api/pipelines/__init__.py
+++ b/model_api/python/model_api/pipelines/__init__.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 from .async_pipeline import AsyncPipeline
 
 __all__ = ["AsyncPipeline"]

--- a/model_api/python/model_api/pipelines/async_pipeline.py
+++ b/model_api/python/model_api/pipelines/async_pipeline.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/pipelines/async_pipeline.py
+++ b/model_api/python/model_api/pipelines/async_pipeline.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2020-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from time import perf_counter
 

--- a/model_api/python/model_api/tilers/__init__.py
+++ b/model_api/python/model_api/tilers/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/tilers/__init__.py
+++ b/model_api/python/model_api/tilers/__init__.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2023-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from .detection import DetectionTiler
 from .instance_segmentation import InstanceSegmentationTiler

--- a/model_api/python/model_api/tilers/detection.py
+++ b/model_api/python/model_api/tilers/detection.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/tilers/detection.py
+++ b/model_api/python/model_api/tilers/detection.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2023-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import cv2 as cv
 import numpy as np

--- a/model_api/python/model_api/tilers/instance_segmentation.py
+++ b/model_api/python/model_api/tilers/instance_segmentation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/tilers/instance_segmentation.py
+++ b/model_api/python/model_api/tilers/instance_segmentation.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2023-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from contextlib import contextmanager
 

--- a/model_api/python/model_api/tilers/semantic_segmentation.py
+++ b/model_api/python/model_api/tilers/semantic_segmentation.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/model_api/tilers/semantic_segmentation.py
+++ b/model_api/python/model_api/tilers/semantic_segmentation.py
@@ -1,17 +1,7 @@
-"""Copyright (C) 2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 from __future__ import annotations
 

--- a/model_api/python/model_api/tilers/tiler.py
+++ b/model_api/python/model_api/tilers/tiler.py
@@ -1,17 +1,7 @@
-"""Copyright (c) 2023-2024 Intel Corporation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 
 import abc
 import logging as log

--- a/model_api/python/model_api/tilers/tiler.py
+++ b/model_api/python/model_api/tilers/tiler.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/model_api/python/pyproject.toml
+++ b/model_api/python/pyproject.toml
@@ -1,3 +1,4 @@
+#
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/cpp/accuracy/test_YOLOv8.cpp
+++ b/tests/cpp/accuracy/test_YOLOv8.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <gtest/gtest.h>

--- a/tests/cpp/accuracy/test_YOLOv8.cpp
+++ b/tests/cpp/accuracy/test_YOLOv8.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <gtest/gtest.h>
 #include <models/detection_model.h>
 #include <models/input_data.h>

--- a/tests/cpp/accuracy/test_accuracy.cpp
+++ b/tests/cpp/accuracy/test_accuracy.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <adapters/openvino_adapter.h>
 #include <gtest/gtest.h>
 #include <models/anomaly_model.h>

--- a/tests/cpp/accuracy/test_accuracy.cpp
+++ b/tests/cpp/accuracy/test_accuracy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <adapters/openvino_adapter.h>

--- a/tests/cpp/precommit/test_model_config.cpp
+++ b/tests/cpp/precommit/test_model_config.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <adapters/openvino_adapter.h>
 #include <gtest/gtest.h>
 #include <models/classification_model.h>

--- a/tests/cpp/precommit/test_model_config.cpp
+++ b/tests/cpp/precommit/test_model_config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <adapters/openvino_adapter.h>

--- a/tests/cpp/precommit/test_sanity.cpp
+++ b/tests/cpp/precommit/test_sanity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2020-2024 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <gtest/gtest.h>

--- a/tests/cpp/precommit/test_sanity.cpp
+++ b/tests/cpp/precommit/test_sanity.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2022-2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include <gtest/gtest.h>
 #include <models/classification_model.h>
 #include <models/detection_model.h>

--- a/tests/python/accuracy/conftest.py
+++ b/tests/python/accuracy/conftest.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 import json
 
 import pytest

--- a/tests/python/accuracy/conftest.py
+++ b/tests/python/accuracy/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json

--- a/tests/python/accuracy/prepare_data.py
+++ b/tests/python/accuracy/prepare_data.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 import argparse

--- a/tests/python/accuracy/prepare_data.py
+++ b/tests/python/accuracy/prepare_data.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 import argparse
 import asyncio
 from io import BytesIO

--- a/tests/python/accuracy/test_YOLOv8.py
+++ b/tests/python/accuracy/test_YOLOv8.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 import functools
 import os
 import types

--- a/tests/python/accuracy/test_YOLOv8.py
+++ b/tests/python/accuracy/test_YOLOv8.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 import functools

--- a/tests/python/accuracy/test_accuracy.py
+++ b/tests/python/accuracy/test_accuracy.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 import json
 import os
 from pathlib import Path

--- a/tests/python/accuracy/test_accuracy.py
+++ b/tests/python/accuracy/test_accuracy.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json

--- a/tests/python/precommit/test_load.py
+++ b/tests/python/precommit/test_load.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 from model_api.models import Model
 
 

--- a/tests/python/precommit/test_load.py
+++ b/tests/python/precommit/test_load.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 from model_api.models import Model

--- a/tests/python/precommit/test_save.py
+++ b/tests/python/precommit/test_save.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 from model_api.models import Model
 
 

--- a/tests/python/precommit/test_save.py
+++ b/tests/python/precommit/test_save.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 from model_api.models import Model

--- a/tests/python/precommit/test_utils.py
+++ b/tests/python/precommit/test_utils.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
 import numpy as np
 import openvino.runtime as ov
 from model_api.adapters.utils import (

--- a/tests/python/precommit/test_utils.py
+++ b/tests/python/precommit/test_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2020-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 import numpy as np


### PR DESCRIPTION
# What does this PR do?

Replaces outdated long headers with the new short ones
Tool used for the replacement: `licenseheaders`