### PR TITLE
Fix missing checks in merge queue

### DIFF
--- a/.github/workflows/test_accuracy.yml
+++ b/.github/workflows/test_accuracy.yml
@@ -1,6 +1,10 @@
 name: test_accuracy
 permissions: read-all
-on: pull_request
+on:
+  pull_request:
+  merge_group:
+    branches:
+      - master
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
# What does this PR do?

Previously, accuracy tests were now launched, but the queue was waiting till the status is reported
