### PR TITLE
CVS-156311 fix corner case in contours detection

### DIFF
--- a/model_api/cpp/models/include/models/results.h
+++ b/model_api/cpp/models/include/models/results.h
@@ -230,9 +230,11 @@ static inline std::vector<SegmentedObjectWithRects> add_rotated_rects(std::vecto
         for (size_t i = 0; i < contours.size(); i++) {
             contour.insert(contour.end(), contours[i].begin(), contours[i].end());
         }
-        std::vector<cv::Point> hull;
-        cv::convexHull(contour, hull);
-        objects_with_rects.back().rotated_rect = cv::minAreaRect(hull);
+        if (contour.size() > 0) {
+            std::vector<cv::Point> hull;
+            cv::convexHull(contour, hull);
+            objects_with_rects.back().rotated_rect = cv::minAreaRect(hull);
+        }
     }
     return objects_with_rects;
 }


### PR DESCRIPTION
# What does this PR do?

Fixes CVS-155311

This PR fixes corner case, where detected contours were 0:
`Calculator::Process() for node "RotatedDetectionCalculator" failed: ; RET_CHECK failure (external/geti_calculators/inference/geti_calculator_base.h:32) false
Caught exception with message: OpenCV(4.10.0) /opt/opencv_repo/modules/imgproc/src/convhull.cpp:143: error: (-215:Assertion failed) total >= 0 && (depth == CV_32F || depth == CV_32S) in function 'convexHull'
`