### PR TITLE
Replace unnamed tuple in cls result with a label object

### DIFF
--- a/model_api/python/model_api/models/action_classification.py
+++ b/model_api/python/model_api/models/action_classification.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from model_api.adapters.utils import RESIZE_TYPES, InputTransform
+from model_api.models.result_types import Label
 
 from .model import Model
 from .result_types import ClassificationResult
@@ -223,7 +224,7 @@ class ActionClassificationModel(Model):
         logits = next(iter(outputs.values())).squeeze()
         index = np.argmax(logits)
         return ClassificationResult(
-            [(index, self.labels[index], logits[index])],
+            [Label(int(index), self.labels[index], logits[index])],
             np.ndarray(0),
             np.ndarray(0),
             np.ndarray(0),

--- a/model_api/python/model_api/models/result_types/__init__.py
+++ b/model_api/python/model_api/models/result_types/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .anomaly import AnomalyResult
-from .classification import ClassificationResult
+from .classification import ClassificationResult, Label
 from .detection import Detection, DetectionResult
 from .keypoint import DetectedKeypoints
 from .segmentation import (
@@ -23,6 +23,7 @@ __all__ = [
     "Detection",
     "DetectionResult",
     "DetectedKeypoints",
+    "Label",
     "SegmentedObject",
     "SegmentedObjectWithRects",
     "ImageResultWithSoftPrediction",

--- a/model_api/python/model_api/models/result_types/classification.py
+++ b/model_api/python/model_api/models/result_types/classification.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generator
 
 from .utils import array_shape_to_str
 
@@ -13,12 +13,34 @@ if TYPE_CHECKING:
     import numpy as np
 
 
+class Label:
+    """Entity representing a predicted label."""
+
+    def __init__(
+        self,
+        id: int | None = None,
+        name: str | None = None,
+        confidence: float | None = None,
+    ) -> None:
+        self.name = name
+        self.confidence = confidence
+        self.id = id
+
+    def __iter__(self) -> Generator:
+        output = (self.id, self.name, self.confidence)
+        for i in output:
+            yield i
+
+    def __str__(self) -> str:
+        return f"{self.id} ({self.name}): {self.confidence:.3f}"
+
+
 class ClassificationResult:
     """Results for classification models."""
 
     def __init__(
         self,
-        top_labels: list[tuple[int, str, float]] | None = None,
+        top_labels: list[Label] | None = None,
         saliency_map: np.ndarray | None = None,
         feature_vector: np.ndarray | None = None,
         raw_scores: np.ndarray | None = None,
@@ -30,7 +52,7 @@ class ClassificationResult:
 
     def __str__(self) -> str:
         assert self.top_labels is not None
-        labels = ", ".join(f"{idx} ({label}): {confidence:.3f}" for idx, label, confidence in self.top_labels)
+        labels = ", ".join(str(label) for label in self.top_labels)
         return (
             f"{labels}, {array_shape_to_str(self.saliency_map)}, {array_shape_to_str(self.feature_vector)}, "
             f"{array_shape_to_str(self.raw_scores)}"

--- a/tests/python/unit/results/test_cls_result.py
+++ b/tests/python/unit/results/test_cls_result.py
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2020-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import numpy as np
+from model_api.models.result_types import ClassificationResult, Label
+
+
+def test_cls_result():
+    label = Label(1, "label", 0.5)
+    tst_vector = np.array([1, 2, 3])
+    cls_result = ClassificationResult([label], tst_vector, tst_vector, tst_vector)
+
+    assert cls_result.top_labels[0].id == 1
+    assert cls_result.top_labels[0].name == "label"
+    assert cls_result.top_labels[0].confidence == 0.5
+    assert str(cls_result) == "1 (label): 0.500, [3], [3], [3]"
+    assert cls_result.top_labels[0].__str__() == "1 (label): 0.500"
+    assert tuple(cls_result.top_labels[0].__iter__()) == (1, "label", 0.5)


### PR DESCRIPTION
# What does this PR do?

Tuple-like behavior is preserved to avoid client code changes:
```python
predictions: ClassificationResult

for label_idx, label_name, prob in predictions.top_labels:
    ...
```


<!-- Remove if not applicable -->

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
