### PR TITLE
Enable linking against OV python package

### DIFF
--- a/.github/workflows/test_precommit.yml
+++ b/.github/workflows/test_precommit.yml
@@ -97,7 +97,7 @@ jobs:
           source venv/Scripts/activate
           python -m pip install --upgrade pip
           pip install model_api/python/[tests] --extra-index-url https://download.pytorch.org/whl/cpu
-          curl https://storage.openvinotoolkit.org/repositories/openvino/packages/2024.1/windows/w_openvino_toolkit_windows_2024.1.0.15008.f4afc983258_x86_64.zip --output w_openvino_toolkit_windows.zip
+          curl https://storage.openvinotoolkit.org/repositories/openvino/packages/2024.6/windows/w_openvino_toolkit_windows_2024.6.0.17404.4c0f47d2335_x86_64.zip --output w_openvino_toolkit_windows.zip
           unzip w_openvino_toolkit_windows.zip
           rm w_openvino_toolkit_windows.zip
           curl -L https://github.com/opencv/opencv/releases/download/4.10.0/opencv-4.10.0-windows.exe --output opencv-4.10.0-windows.exe
@@ -112,13 +112,13 @@ jobs:
         shell: bash
         run: |
           mkdir build && cd build
-          MSYS_NO_PATHCONV=1 cmake ../examples/cpp/ -DOpenVINO_DIR=$GITHUB_WORKSPACE/w_openvino_toolkit_windows_2024.1.0.15008.f4afc983258_x86_64/runtime/cmake -DOpenCV_DIR=$GITHUB_WORKSPACE/opencv/opencv/build -DCMAKE_CXX_FLAGS=/WX
+          MSYS_NO_PATHCONV=1 cmake ../examples/cpp/ -DOpenVINO_DIR=$GITHUB_WORKSPACE/w_openvino_toolkit_windows_2024.6.0.17404.4c0f47d2335_x86_64/runtime/cmake -DOpenCV_DIR=$GITHUB_WORKSPACE/opencv/opencv/build -DCMAKE_CXX_FLAGS=/WX
           cmake --build . --config Release -j $((`nproc`*2+2))
       - name: Run sync sample
         shell: cmd
         # .\w_openvino_toolkit_windows_2023.0.0.10926.b4452d56304_x86_64\setupvars.bat exits with 0 code without moving to a next command. Set PATH manually
         run: |
-          set PATH=opencv\opencv\build\x64\vc16\bin;w_openvino_toolkit_windows_2024.1.0.15008.f4afc983258_x86_64\runtime\bin\intel64\Release;w_openvino_toolkit_windows_2024.1.0.15008.f4afc983258_x86_64\runtime\3rdparty\tbb\bin;%PATH%
+          set PATH=opencv\opencv\build\x64\vc16\bin;w_openvino_toolkit_windows_2024.6.0.17404.4c0f47d2335_x86_64\runtime\bin\intel64\Release;w_openvino_toolkit_windows_2024.6.0.17404.4c0f47d2335_x86_64\runtime\3rdparty\tbb\bin;%PATH%
           .\build\Release\synchronous_api.exe .\data\public\ssd_mobilenet_v1_fpn_coco\FP16\ssd_mobilenet_v1_fpn_coco.xml .\data\BloodImage_00007.jpg
   serving_api:
     strategy:

--- a/model_api/cpp/CMakeLists.txt
+++ b/model_api/cpp/CMakeLists.txt
@@ -13,7 +13,13 @@ if(NOT GENERATOR_IS_MULTI_CONFIG_VAR AND NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel ...")
 endif()
 
-project(model_api)
+set(model_api_VERSION 0.0.0)
+
+project(model_api
+        VERSION ${model_api_VERSION}
+        DESCRIPTION "OpenVINO Vision API"
+        HOMEPAGE_URL "https://github.com/openvinotoolkit/model_api/"
+        LANGUAGES CXX C)
 
 if(WIN32)
     if(NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
@@ -23,10 +29,21 @@ if(WIN32)
     add_definitions(-DNOMINMAX)
 endif()
 
-set(model_api_VERSION 0.0.0)
-
 find_package(OpenCV REQUIRED COMPONENTS core imgproc)
-find_package(OpenVINO REQUIRED COMPONENTS Runtime)
+
+# Looking for OpenVINO in the python distribution. It doesn't work for cross-compiling build
+if(NOT CMAKE_CROSSCOMPILING)
+    find_package(Python3 REQUIRED)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c "from openvino.utils import get_cmake_path; print(get_cmake_path(), end='')"
+        OUTPUT_VARIABLE OpenVINO_DIR_PY
+        ERROR_QUIET
+    )
+endif()
+
+find_package(OpenVINO REQUIRED
+             COMPONENTS Runtime Threading
+             HINTS "${OpenVINO_DIR_PY}")
 
 include(FetchContent)
 FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)

--- a/model_api/cpp/CMakeLists.txt
+++ b/model_api/cpp/CMakeLists.txt
@@ -46,7 +46,7 @@ find_package(OpenVINO REQUIRED
              HINTS "${OpenVINO_DIR_PY}")
 
 include(FetchContent)
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
 FetchContent_MakeAvailable(json)
 
 file(GLOB MODELS_SOURCES ./models/src/*.cpp)


### PR DESCRIPTION
# What does this PR do?

OV installation process implies downloading a .deb package or adding a PPA. This PR relaxes this requirement a bit by utilizing recently introduced in OV mechanism. Now, we can use binaries from OV python package, which is easy to install.
