### PR TITLE
Fix cmake deprecation failure coming from 3rd party

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -37,7 +37,9 @@ find_package(OpenVINO REQUIRED
              COMPONENTS Runtime Threading)
 
 include(FetchContent)
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+FetchContent_Declare(json GIT_REPOSITORY https://github.com/nlohmann/json.git
+                          GIT_TAG d41ca94fa85d5119852e2f7a3f94335cc7cb0486  # PR #4709, fixes cmake deprecation warnings
+                    )
 FetchContent_MakeAvailable(json)
 
 file(GLOB MODELS_SOURCES ./models/src/*.cpp)

--- a/tests/cpp/accuracy/CMakeLists.txt
+++ b/tests/cpp/accuracy/CMakeLists.txt
@@ -54,7 +54,9 @@ endif()
 include(CMakeParseArguments)
 include(FetchContent)
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
+FetchContent_Declare(json GIT_REPOSITORY https://github.com/nlohmann/json.git
+                          GIT_TAG d41ca94fa85d5119852e2f7a3f94335cc7cb0486  # PR #4709, fixes cmake deprecation warnings
+                    )
 FetchContent_Declare(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG a7f443b80b105f940225332ed3c31f2790092f47  # latest main

--- a/tests/cpp/cmake/common.cmake
+++ b/tests/cpp/cmake/common.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.26)
 
 macro(add_test)
     set(oneValueArgs NAME OPENCV_VERSION_REQUIRED)

--- a/tests/cpp/precommit/CMakeLists.txt
+++ b/tests/cpp/precommit/CMakeLists.txt
@@ -53,7 +53,9 @@ endif()
 include(CMakeParseArguments)
 include(FetchContent)
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
+FetchContent_Declare(json GIT_REPOSITORY https://github.com/nlohmann/json.git
+                          GIT_TAG d41ca94fa85d5119852e2f7a3f94335cc7cb0486  # PR #4709, fixes cmake deprecation warnings
+                    )
 FetchContent_Declare(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG a7f443b80b105f940225332ed3c31f2790092f47  # latest main


### PR DESCRIPTION
# What does this PR do?

json lib has outdated cmake min version (<3.5) in the latest release -> switching a git commit containing a fix
See https://github.com/nlohmann/json/pull/4709

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
