### PR TITLE
chore(tests): skip test_scope.json file creation when not needed

### DIFF
--- a/tests/accuracy/conftest.py
+++ b/tests/accuracy/conftest.py
@@ -47,5 +47,9 @@ def pytest_runtest_makereport(item, call):
 
     if result.when == "call":
         test_results = item.config.test_results
+
+        if not test_results:
+            return
+
         with Path("test_scope.json").open("w") as outfile:
             json.dump(test_results, outfile, indent=4)


### PR DESCRIPTION
# What does this PR do?

File `test_scope.json` will now be created only if `--dump` option was used.

Fixes: #436 