### PR TITLE
fix(ci): add required permission

### DIFF
--- a/.github/workflows/test_precommit.yml
+++ b/.github/workflows/test_precommit.yml
@@ -80,6 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write # Needed to upload the results in SARIF
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
This PR adds required permissions to fix `Error: Resource not accessible by integration` ([log](https://github.com/open-edge-platform/model_api/actions/runs/20059670113/job/57533230189)).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
