### PR TITLE
ci: update `merge_group` trigger logic in `security-scan.yml`

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Run Zizmor scan
         uses: open-edge-platform/geti-ci/actions/zizmor@3a4b81ea648711eb638b34757427cd3ef71d19f1
         with:
-          scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
+          scan-scope: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'changed' || 'all' }}
           severity-level: "LOW"
           confidence-level: "LOW"
-          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          fail-on-findings: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'true' || 'false' }}
 
   bandit-scan:
     runs-on: ubuntu-latest
@@ -55,15 +55,15 @@ jobs:
       - name: Run Bandit scan
         uses: open-edge-platform/geti-ci/actions/bandit@3a4b81ea648711eb638b34757427cd3ef71d19f1
         with:
-          scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
+          scan-scope: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'changed' || 'all' }}
           severity-level: "LOW"
           confidence-level: "LOW"
           config_file: "pyproject.toml"
-          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          fail-on-findings: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'true' || 'false' }}
 
   trivy-scan:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       security-events: write # Needed to upload the results to code-scanning dashboard
@@ -96,6 +96,6 @@ jobs:
       - name: Run Semgrep scan
         uses: open-edge-platform/geti-ci/actions/semgrep@3a4b81ea648711eb638b34757427cd3ef71d19f1
         with:
-          scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
+          scan-scope: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'changed' || 'all' }}
           severity: "LOW"
-          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          fail-on-findings: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'true' || 'false' }}


### PR DESCRIPTION
# What does this PR do?

This PR updates the `.github/workflows/security-scan.yml` workflow to ensure that security scans treat `merge_group` trigger the same as `pull_request`.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
