### PR TITLE
fix(tests): temporarily remove python 3.14 on windows-latest

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -52,6 +52,9 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+        exclude:
+          - os: "windows-latest"
+            python-version: "3.14" # started to fail with "Windows fatal exception: access violation"
     runs-on: ${{ matrix.os }}
     steps:
       - *checkout


### PR DESCRIPTION
Temporarily disable running accuracy tests on python 3.14 on windows-latest as it started to fail with "Windows fatal exception: access violation" recently