### PR TITLE
Disable uv upgrade by renovate bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,23 @@
       schedule: ["* * 1 * *"],
       matchPackageNames: ["*"],
     },
+    // uv version used in GitHub Actions is updated manually
+    {
+      enabled: false,
+      matchDatasources: ["github-releases"],
+      matchDepNames: ["astral-sh/uv"],
+      matchDepTypes: ["uses-with"],
+    },
+  ],
+  // Is used to upgrade Renovate version
+  customManagers: [
+    {
+      fileMatch: ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)",
+        "# renovate: datasource=(?<datasource>.*?)\\s+export RENOVATE_IMAGE=(?<depName>[^:]+):(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
+      ],
+    },
   ],
   vulnerabilityAlerts: {
     enabled: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,7 @@
     "helpers:pinGitHubActionDigests",
   ],
   baseBranchPatterns: ["master"],
-  enabledManagers: ["github-actions", "pep621"],
+  enabledManagers: ["github-actions", "pep621", "custom.regex"],
   ignorePresets: [":prHourlyLimit2"],
   prHourlyLimit: 10,
   packageRules: [
@@ -28,7 +28,7 @@
       enabled: true,
       separateMajorMinor: false,
       groupName: "GitHub Actions",
-      matchManagers: ["github-actions"],
+      matchManagers: ["github-actions", "custom.regex"],
       schedule: ["* * 1 * *"],
       matchPackageNames: ["*"],
     },

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -37,6 +37,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             files.pythonhosted.org:443
+            ghcr.io:443
             github.com:443
             pypi.org:443
             raw.githubusercontent.com:443

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Validate configuration
         run: |
           # renovate: datasource=docker
-          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:43.185
+          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:43.160.2@sha256:e977df2dbd4b978cc301a0b4d8e0162ec4ce08bd205422c02c4cf55f52b67336
           docker run --rm --entrypoint "renovate-config-validator" \
           -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5" \
           ${RENOVATE_IMAGE} "/renovate.json5"

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -39,6 +39,7 @@ jobs:
             files.pythonhosted.org:443
             ghcr.io:443
             github.com:443
+            pkg-containers.githubusercontent.com:443
             pypi.org:443
             raw.githubusercontent.com:443
             releases.astral.sh:443

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -77,6 +77,8 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
+          # renovate: datasource=github-releases depName=renovatebot/renovate
+          renovate-version: 43.160.7
           configurationFile: .github/renovate.json5
           token: "${{ steps.get-github-app-token.outputs.token }}"
         env:


### PR DESCRIPTION
# What does this PR do?

Disable uv upgrade by renovate bot and fix version of renovate in a way that it can update itself.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
