### PR TITLE
Bump Model API version to 0.4.6

### DIFF
--- a/model_api/pyproject.toml
+++ b/model_api/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openvino_model_api"
-version = "0.4.5"
+version = "0.4.6"
 requires-python = ">=3.11"
 authors = [
   {name = "Intel(R) Corporation"},

--- a/model_api/uv.lock
+++ b/model_api/uv.lock
@@ -2027,7 +2027,7 @@ wheels = [
 
 [[package]]
 name = "openvino-model-api"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/model_converter/uv.lock
+++ b/model_converter/uv.lock
@@ -1327,7 +1327,7 @@ wheels = [
 
 [[package]]
 name = "openvino-model-api"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "../model_api" }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
# What does this PR do?

Bump Model API version to 0.4.6