### PR TITLE
fix(tilers): allow skipping expensive per-tile saliency map merge

### DIFF
--- a/model_api/src/model_api/tilers/detection.py
+++ b/model_api/src/model_api/tilers/detection.py
@@ -23,10 +23,19 @@ class DetectionTiler(Tiler[DetResultT]):
     """Tiler for object detection models.
     This tiler expects model to output a lsit of `Detection` objects
     or one `DetectionResult` object.
+
+    Note:
+        Merging per-tile saliency maps (see `_merge_saliency_maps`) is a
+        per-class, pixel-by-pixel operation whose cost scales with
+        `num_tiles * num_classes * H * W`. For large images tiled with the
+        default configuration (hundreds of tiles), this can take from minutes
+        to hours. If the caller does not need saliency maps, construct this
+        tiler with `merge_saliency_maps=False` (or set the attribute at any
+        time before calling) to skip that work entirely.
     """
 
-    def __init__(self, model, configuration: dict = {}, execution_mode="async"):
-        super().__init__(model, configuration, execution_mode)
+    def __init__(self, model, configuration: dict = {}, execution_mode="async", merge_saliency_maps: bool = True):
+        super().__init__(model, configuration, execution_mode, merge_saliency_maps)
 
     @classmethod
     def parameters(cls):
@@ -104,7 +113,11 @@ class DetectionTiler(Tiler[DetResultT]):
             detections_array = detections_array[keep]
 
         merged_vector = np.mean(feature_vectors, axis=0) if feature_vectors else np.ndarray(0)
-        saliency_map = self._merge_saliency_maps(saliency_maps, shape, tiles_coords) if saliency_maps else np.ndarray(0)
+        saliency_map = (
+            self._merge_saliency_maps(saliency_maps, shape, tiles_coords)
+            if saliency_maps and self.merge_saliency_maps
+            else np.ndarray(0)
+        )
         label_names = [self.model.get_label_name(int(label_idx)) for label_idx in detections_array[:, 0]]
 
         return cast(

--- a/model_api/src/model_api/tilers/instance_segmentation.py
+++ b/model_api/src/model_api/tilers/instance_segmentation.py
@@ -30,6 +30,7 @@ class InstanceSegmentationTiler(DetectionTiler[InstanceSegmentationResult]):
         configuration: dict = {},
         execution_mode="async",
         tile_classifier_model=None,
+        merge_saliency_maps: bool = True,
     ):
         """Constructor for creating a semantic segmentation tiling pipeline
 
@@ -39,8 +40,11 @@ class InstanceSegmentationTiler(DetectionTiler[InstanceSegmentationResult]):
             tiler (`tile_size`, `tiles_overlap` etc.) which are set as data attributes.
             execution_mode: Controls inference mode of the tiler (`async` or `sync`).
             tile_classifier_model: an `ImageModel`, which has "tile_prob" output.
+            merge_saliency_maps: Whether to merge per-tile saliency maps into the
+              final result. Set to `False` to skip that work when saliency maps are
+              not needed by the caller. Defaults to `True`.
         """
-        super().__init__(model, configuration, execution_mode)
+        super().__init__(model, configuration, execution_mode, merge_saliency_maps)
         self.tile_classifier_model = tile_classifier_model
 
     def _filter_tiles(self, image, tile_coords, confidence_threshold=0.35):
@@ -120,7 +124,11 @@ class InstanceSegmentationTiler(DetectionTiler[InstanceSegmentationResult]):
         masks = [masks[keep_idx] for keep_idx in keep_idxs]
 
         merged_vector = np.mean(feature_vectors, axis=0) if feature_vectors else np.ndarray(0)
-        saliency_map = self._merge_saliency_maps(saliency_maps, shape, tiles_coords) if saliency_maps else []
+        saliency_map = (
+            self._merge_saliency_maps(saliency_maps, shape, tiles_coords)
+            if saliency_maps and self.merge_saliency_maps
+            else []
+        )
 
         labels, scores, bboxes = np.hsplit(detections_array, [1, 2])
         labels = labels.astype(np.int32)

--- a/model_api/src/model_api/tilers/tiler.py
+++ b/model_api/src/model_api/tilers/tiler.py
@@ -33,9 +33,24 @@ class Tiler(abc.ABC, Generic[ResultT]):
         model_loaded (bool): a flag whether the model is loaded to device
         async_pipeline (AsyncPipeline): a pipeline for asynchronous execution mode
         execution_mode: Controls inference mode of the tiler (`async` or `sync`).
+        merge_saliency_maps (bool): Whether per-tile saliency maps (and, where
+            applicable, feature vectors) should be merged into the final result.
+            Subclasses that produce saliency maps (e.g. `DetectionTiler`) merge
+            them with a per-class, and in some cases per-pixel, operation whose
+            cost scales with the number of tiles. When the caller does not need
+            saliency maps (for example when only computing accuracy metrics
+            rather than an explanation), set this to `False` -- either at
+            construction time or at any point afterwards, since it is a plain
+            mutable attribute -- to skip that work entirely.
     """
 
-    def __init__(self, model, configuration: dict = {}, execution_mode: str = "async"):
+    def __init__(
+        self,
+        model,
+        configuration: dict = {},
+        execution_mode: str = "async",
+        merge_saliency_maps: bool = True,
+    ):
         """Base constructor for creating a tiling pipeline
 
         Args:
@@ -43,6 +58,9 @@ class Tiler(abc.ABC, Generic[ResultT]):
             configuration: it contains values for parameters accepted by specific
               tiler (`tile_size`, `tiles_overlap` etc.) which are set as data attributes.
             execution_mode: Controls inference mode of the tiler (`async` or `sync`).
+            merge_saliency_maps: Whether to merge per-tile saliency maps (and feature
+              vectors, where applicable) into the final result. Ignored by tilers that
+              do not produce saliency maps. Defaults to `True`.
         """
         self.logger = log.getLogger()
         self.model = model
@@ -54,6 +72,7 @@ class Tiler(abc.ABC, Generic[ResultT]):
             msg = f"Wrong execution mode. The following modes are supported {Tiler.EXECUTION_MODES}"
             raise ValueError(msg)
         self.execution_mode = execution_mode
+        self.merge_saliency_maps = merge_saliency_maps
 
     def get_model(self):
         """Getter for underlying model"""

--- a/model_api/tests/unit/tilers/test_detection_tiler.py
+++ b/model_api/tests/unit/tilers/test_detection_tiler.py
@@ -39,6 +39,12 @@ class TestDetectionTilerInit:
         tiler = DetectionTiler(model, execution_mode="sync")
         assert tiler.max_pred_number == 100
         assert tiler.iou_threshold == 0.45
+        assert tiler.merge_saliency_maps is True
+
+    def test_init_merge_saliency_maps_false(self):
+        model = _make_model()
+        tiler = DetectionTiler(model, execution_mode="sync", merge_saliency_maps=False)
+        assert tiler.merge_saliency_maps is False
 
     def test_parameters_includes_detection_params(self):
         params = DetectionTiler.parameters()

--- a/model_api/tests/unit/tilers/test_instance_segmentation_tiler.py
+++ b/model_api/tests/unit/tilers/test_instance_segmentation_tiler.py
@@ -39,12 +39,18 @@ class TestInstanceSegmentationTilerInit:
         model = _make_model()
         tiler = InstanceSegmentationTiler(model, execution_mode="sync")
         assert tiler.tile_classifier_model is None
+        assert tiler.merge_saliency_maps is True
 
     def test_init_with_classifier(self):
         model = _make_model()
         classifier = MagicMock()
         tiler = InstanceSegmentationTiler(model, execution_mode="sync", tile_classifier_model=classifier)
         assert tiler.tile_classifier_model is classifier
+
+    def test_init_merge_saliency_maps_false(self):
+        model = _make_model()
+        tiler = InstanceSegmentationTiler(model, execution_mode="sync", merge_saliency_maps=False)
+        assert tiler.merge_saliency_maps is False
 
 
 class TestInstanceSegmentationTilerFilterTiles:
@@ -121,6 +127,30 @@ class TestInstanceSegmentationTilerMergeResults:
         ]
         merged = tiler._merge_results(results, (100, 100, 3))  # noqa: SLF001
         assert isinstance(merged, InstanceSegmentationResult)
+
+    @patch("model_api.tilers.instance_segmentation.multiclass_nms")
+    @patch("model_api.tilers.instance_segmentation._segm_postprocess")
+    def test_merge_results_skips_saliency_merge_when_disabled(self, mock_segm, mock_nms):
+        """merge_saliency_maps=False must skip the saliency merge entirely."""
+        model = _make_model()
+        tiler = InstanceSegmentationTiler(model, execution_mode="sync", merge_saliency_maps=False)
+        mock_nms.return_value = np.array([0])
+        mock_segm.return_value = np.ones((100, 100), dtype=np.uint8)
+
+        results = [
+            {
+                "bboxes": np.array([[0, 0.9, 10, 20, 50, 60]], dtype=np.float32),
+                "features": np.array([1.0]),
+                "saliency_map": [np.ones((10, 10), dtype=np.float32)],
+                "coords": [0, 0, 100, 100],
+                "masks": [np.ones((40, 40), dtype=np.uint8)],
+            },
+        ]
+        with patch.object(tiler, "_merge_saliency_maps") as mock_merge_saliency:
+            merged = tiler._merge_results(results, (100, 100, 3))  # noqa: SLF001
+        mock_merge_saliency.assert_not_called()
+        assert isinstance(merged, InstanceSegmentationResult)
+        assert merged.saliency_map == []
 
 
 class TestInstanceSegmentationTilerMergeSaliencyMaps:

--- a/model_api/tests/unit/tilers/test_tiler.py
+++ b/model_api/tests/unit/tilers/test_tiler.py
@@ -38,6 +38,7 @@ class TestTilerInit:
         assert tiler.tile_size == 400
         assert tiler.tiles_overlap == 0.5
         assert tiler.tile_with_full_img is True
+        assert tiler.merge_saliency_maps is True
 
     def test_init_sync_mode(self):
         model = _make_model()
@@ -59,6 +60,20 @@ class TestTilerInit:
         model = _make_model()
         tiler = ConcreteTiler(model)
         assert tiler.get_model() is model
+
+    def test_init_merge_saliency_maps_false(self):
+        """merge_saliency_maps can be disabled at construction time."""
+        model = _make_model()
+        tiler = ConcreteTiler(model, merge_saliency_maps=False)
+        assert tiler.merge_saliency_maps is False
+
+    def test_merge_saliency_maps_mutable_after_construction(self):
+        """merge_saliency_maps is a plain mutable attribute, toggleable per call."""
+        model = _make_model()
+        tiler = ConcreteTiler(model)
+        assert tiler.merge_saliency_maps is True
+        tiler.merge_saliency_maps = False
+        assert tiler.merge_saliency_maps is False
 
 
 class TestTilerParameters:


### PR DESCRIPTION
DetectionTiler._merge_saliency_maps merges per-tile saliency maps with a pure-Python, pixel-by-pixel nested loop (cost O(num_tiles * num_classes * H * W)). With the default tiling configuration (tile_size=400, tiles_overlap=0.5), a single large image can be split into hundreds of tiles, making that merge take minutes to hours for callers that never use the merged saliency map (e.g. when only computing detection accuracy metrics rather than an explanation).

Add a merge_saliency_maps: bool = True constructor parameter/attribute to the base Tiler class (inherited by DetectionTiler and InstanceSegmentationTiler). When set to False, the expensive per-tile saliency merge is skipped entirely. It is a plain mutable attribute so callers can toggle it at any time, not just at construction. Defaults to True, preserving existing behavior.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
